### PR TITLE
Restore support for engines without lookbehind

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,12 @@
 'use strict';
-const issueRegex = require('issue-regex');
 const createHtmlElement = require('create-html-element');
 
-const groupedIssueRegex = new RegExp(`(${issueRegex().source})`, 'g');
+let groupedIssueRegex;
+try {
+	groupedIssueRegex = new RegExp('((?:(?<![\\/\\w-.])\\w[\\w-.]+\\/\\w[\\w-.]+|\\B)#[1-9]\\d*\\b)', 'g');
+} catch (error) {
+	groupedIssueRegex = new RegExp('((?:\\w[\\w-.]+\\/\\w[\\w-.]+|\\B)#[1-9]\\d*\\b)', 'g');
+}
 
 // Get `<a>` element as string
 const linkify = (match, options) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "linkify-issues",
-	"version": "2.0.0",
+	"version": "2.0.0-nolookbehind",
 	"description": "Linkify GitHub issue references",
 	"license": "MIT",
 	"repository": "sindresorhus/linkify-issues",


### PR DESCRIPTION
This has been published under the tag `nolookbehind` as a one-off upgrade path for v1 users. It's not meant to be merged into `master`.

Install it with 

```sh
npm i linkify-issues@nolookbehind
```